### PR TITLE
Update publish-to-ar.sh to also install `build` module

### DIFF
--- a/publish-to-ar.sh
+++ b/publish-to-ar.sh
@@ -4,6 +4,7 @@ pip install -U \
     keyring \
     twine \
     setuptools \
+    build \
     wheel > /dev/null
 pip install -U keyrings.google-artifactregistry-auth > /dev/null
 


### PR DESCRIPTION
Without it, I was not able to execute the `python3 -m build --wheel`, but it succeeded after I simply ran `pip install build`